### PR TITLE
Minor bug in Packet.shift

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.vngx</groupId>
+	<groupId>com.gnshealthcare</groupId>
 	<artifactId>vngx-jsch</artifactId>
 	<packaging>bundle</packaging>
-	<version>0.10</version>
+	<version>0.10-SNAPSHOT</version>
 	<name>vngx-jsch</name>
 	<url>http://maven.apache.org</url>
 	<description>**vngx-jsch** (beta) is an updated version of the popular JSch SSH library 

--- a/src/main/java/org/vngx/jsch/Packet.java
+++ b/src/main/java/org/vngx/jsch/Packet.java
@@ -181,7 +181,7 @@ public final class Packet {
 		/* If shifting to add the MAC to end of packet is greater than the packet
 		 * length, then create new larger buffer to hold packet and copy data
 		 * into it and replace internal byte array of buffer. */
-		buffer.ensureCapacity(offset + buffer.index - 5 - 9 - length);
+		buffer.ensureCapacity(offset - 5 - 9 - length);
 
 		System.arraycopy(buffer.buffer, length + 5 + 9, buffer.buffer, offset, buffer.index - 5 - 9 - length);
 


### PR DESCRIPTION
It was including the index when it called Buffer.ensureCapacity.  That function already adds in the index, so you could run into problems as you get close to the maximum packet size.
